### PR TITLE
Горизонтальный скролл в трассировке

### DIFF
--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/trace/TraceView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/trace/TraceView.java
@@ -35,6 +35,8 @@ import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
@@ -60,9 +62,9 @@ import ru.bmstu.rk9.rao.lib.database.Database.EntryType;
 import ru.bmstu.rk9.rao.lib.database.Database.TypeSize;
 import ru.bmstu.rk9.rao.lib.notification.Subscriber;
 import ru.bmstu.rk9.rao.lib.simulator.CurrentSimulator;
-import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager;
 import ru.bmstu.rk9.rao.lib.simulator.CurrentSimulator.ExecutionState;
 import ru.bmstu.rk9.rao.lib.simulator.CurrentSimulator.SimulatorState;
+import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager;
 import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager.SimulatorSubscriberInfo;
 import ru.bmstu.rk9.rao.ui.export.ExportTraceHandler;
 import ru.bmstu.rk9.rao.ui.gef.process.ProcessColors;
@@ -123,6 +125,14 @@ public class TraceView extends ViewPart {
 	@Override
 	public void createPartControl(Composite parent) {
 		viewer = new TableViewer(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.VIRTUAL);
+
+		// This updates size of the column and sets correct horizontal slider width
+		viewer.getTable().addPaintListener(new PaintListener() {
+			@Override
+			public void paintControl(PaintEvent e) {
+				viewer.getTable().getColumn(0).pack();
+			}
+		});
 
 		TableViewerColumn column = new TableViewerColumn(viewer, SWT.NONE);
 		TableColumnLayout tableLayout = new TableColumnLayout();


### PR DESCRIPTION
Основная проблема исходит из того, что нужно программно пересчитывать размер колонки, в которой находится трассировка. Как только пересчет произведен корректно, горизонтальный скролл автоматически начинает нормально работать.

Как логичное решение предлагается сделать пересчет размеров на событие resize. Однако, если так сделать, то скролл корректно масштабируется только если уменьшать размер окна, а когда начинаем увеличивать размер окна, то скролл исчезает.

Дебагом классов swt удалось выяснить, что внутренний диспатчер ивентов swt вызывает на каждый ресайз окна 2 события - одно нативное от layout'а, которое присваивает колонке ширину родителя т.е. всей таблицы (следовательно ширина фиксированная и скролл пропадает) и одно моё, которое я вызываю методом `pack()` на каждый ресайз окна. Причем, когда окно уменьшается, сначала вызывается нативный вызов, а затем мой, но когда окно увеличивается, происходит ровно наоборот и скролл исчезает, так как мой пересчет перекрывается неправильным нативным.

Как наиболее близкое событие к ресайзу я выбрал событие отрисовки контрола. Оно уже работает как часы)
